### PR TITLE
More flexible b_fsrivate

### DIFF
--- a/bsd/sys/buf_internal.h
+++ b/bsd/sys/buf_internal.h
@@ -126,6 +126,7 @@ struct buf {
 	TAILQ_ENTRY(buf)        b_act;  /* Device driver queue when active */
 	void *  b_drvdata;              /* Device driver private use */
 	void *  b_fsprivate;            /* filesystem private use */
+	void    (*b_fsprivate_done)(void *);   /* callback for fs to cleanup its data. */
 	void *  b_transaction;          /* journal private use */
 	int     b_dirtyoff;             /* Offset in buffer of dirty region. */
 	int     b_dirtyend;             /* Offset of end of dirty region. */

--- a/tools/lldbmacros/memory.py
+++ b/tools/lldbmacros/memory.py
@@ -4151,7 +4151,7 @@ def _GetBufSummary(buf):
         buf.b_flags, buf.b_lflags, buf.b_error, buf.b_bufsize, buf.b_bcount, buf.b_resid,
         buf.b_dev, buf.b_datap, buf.b_lblkno, buf.b_blkno, buf.b_iodone, buf.b_vp,
         buf.b_rcred, buf.b_wcred, buf.b_upl, buf.b_real_bp, buf.b_act, buf.b_drvdata,
-        buf.b_fsprivate, buf.b_transaction, buf.b_dirtyoff, buf.b_dirtyend, buf.b_validoff,
+        buf.b_fsprivate, buf.b_fsprivate_done, buf.b_transaction, buf.b_dirtyoff, buf.b_dirtyend, buf.b_validoff,
         buf.b_validend, buf.b_redundancy_flags, buf.b_proc, buf.b_attr]
 
     # Join an (already decent) string representation of each field


### PR DESCRIPTION
This pull request is merely a suggestion. However, I do believe b_fsrivate either shouldn't exist, or should honor its variable name (and type) correctly.